### PR TITLE
ci: pin github workflows to v14.28 of the speakeasy sdk-generation-action

### DIFF
--- a/.github/workflows/speakeasy/sdk-generation.yaml
+++ b/.github/workflows/speakeasy/sdk-generation.yaml
@@ -1,0 +1,1234 @@
+name: Speakeasy SDK Generation Workflow
+
+on:
+  workflow_call:
+    inputs:
+      speakeasy_version:
+        description: The version of the Speakeasy CLI to use or "latest"
+        default: latest
+        required: false
+        type: string
+      openapi_doc_location:
+        description: The location of the OpenAPI document to use, either a relative path within the repo or a URL to a publicly hosted document
+        required: false
+        type: string
+      openapi_doc_auth_header:
+        description: |-
+          The auth header to use when fetching the OpenAPI document if it is not publicly hosted. For example `Authorization`.
+          If using a private speakeasy hosted document use `x-api-key`. This header will be populated with the openapi_doc_auth_token provided.
+        required: false
+        type: string
+      openapi_docs:
+        description: |-
+          A yaml string containing a list of OpenAPI documents to use, if multiple documents are provided they will be merged together, prior to generation.
+
+          If the document lives within the repo a relative path can be provided, if the document is hosted publicly a URL can be provided.
+
+          If the documents are hosted privately a URL can be provided along with the `openapi_doc_auth_header` and `openapi_doc_auth_token` inputs.
+          Each document will be fetched using the provided auth header and token, so they need to be valid for all documents.
+
+          For example:
+          openapi_docs: |
+            - https://example.com/openapi1.json
+            - https://example.com/openapi2.json
+        required: false
+        type: string
+      overlay_docs:
+        description: |-
+          A yaml string containing a list of overlay documents to use, if multiple documents are provided they will be applied to the OpenAPI document in the order provided.
+
+          If the document lives within the repo a relative path can be provided, if the document is hosted publicly a URL can be provided.
+
+          If the documents are hosted privately a URL can be provided along with the `openapi_doc_auth_header` and `openapi_doc_auth_token` inputs.
+          Each document will be fetched using the provided auth header and token, so they need to be valid for all documents.
+
+          For example:
+          overlay_docs: |
+            - https://example.com/overlay1.json
+            - https://example.com/overlay2.json
+        required: false
+        type: string
+      languages:
+        description: |-
+          A yaml string containing a list of languages to generate SDKs for example:
+          languages: |
+            - go: ./go-sdk # specifying a output directory
+            - python # using default output of ./python-client-sdk
+            - typescript # using default output of ./typescript-client-sdk
+            - java # using default output of ./java-client-sdk
+            - php # using default output of ./php-client-sdk
+            - csharp # using default output of ./csharp-client-sdk
+            - swift # using default output of ./swift-client-sdk
+            - unity # using default output of ./unity-client-sdk
+            - terraform # (single language repo only)
+
+          If multiple languages are present we will treat this repo as a mono repo, if a single language is present as a single language repo
+        required: true
+        type: string
+      docs_languages:
+        description: |-
+          A yaml string containing a list of languages to generate SDK docs for example:
+          languages: |
+            - go
+            - python
+            - typescript
+            - java
+            - csharp
+            - unity
+            - curl
+        required: false
+        type: string
+      create_release:
+        description: "Create a Github release on generation if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "true"
+        required: false
+        type: string
+      publish_python:
+        description: "Publish the Python SDK to PyPi if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_typescript:
+        description: "Publish the Typescript SDK to NPM if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_terraform:
+        description: "Create a Github release compatible with the terraform registry of the provider"
+        default: "false"
+        required: false
+        type: string
+      publish_java:
+        description: "Publish the Java SDK to the OSSRH URL configured in gen.yml if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_php:
+        description: "Publish the PHP SDK for Composer if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_ruby:
+        description: "Publish the Ruby SDK for RubyGems if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_csharp:
+        description: "Publish the C# SDK for Nuget if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      mode:
+        description: |-
+          The mode to run the workflow in, valid options are 'direct' or 'pr', defaults to 'direct'.
+            - 'direct' will create a commit with the changes to the SDKs and push them directly to the branch the workflow is configure to run on (normally 'main' or 'master').
+              If publishing and creating a release are configured this will happen immediately after the commit is created on the branch.
+            - 'pr' will instead create a new branch to commit the changes to the SDKs to and then create a PR from this branch.
+              The sdk-publish workflow will then need to be configured to run when the PR is merged to publish the SDKs and create a release.
+          See documentation for more details.
+        default: "direct"
+        required: false
+        type: string
+      force:
+        description: "Force the generation of the SDKs"
+        default: "false"
+        required: false
+        type: string
+      output_tests:
+        required: false
+        description: "Internal use only"
+        default: "false"
+        type: string
+      speakeasy_server_url:
+        required: false
+        description: "Internal use only"
+        type: string
+      working_directory:
+        description: "The working directory for running Speakeasy CLI commands in the action"
+        required: false
+        type: string
+      dotnet_version:
+        description: "The version of dotnet to use when compiling the C# SDK"
+        required: false
+        type: string
+        default: "5.x"
+    secrets:
+      github_access_token:
+        description: A GitHub access token with write access to the repo
+        required: true
+      pypi_token:
+        description: A PyPi access token for publishing the package to PyPi, include the `pypi-` prefix
+        required: false
+      npm_token:
+        description: An NPM access token for publishing the package to NPM, include the `npm_` prefix
+        required: false
+      packagist_username:
+        description: A Packagist username for publishing the package to Packagist
+        required: false
+      packagist_token:
+        description: A Packagist API token for publishing the package to Packagist
+        required: false
+      openapi_doc_auth_token:
+        description: The auth token to use when fetching the OpenAPI document if it is not publicly hosted. For example `Bearer <token>` or `<token>`.
+        required: false
+      speakeasy_api_key:
+        description: The API key to use to authenticate the Speakeasy CLI
+        required: true
+      ossrh_username:
+        description: A username for publishing the Java package to the OSSRH URL provided in gen.yml
+        required: false
+      ossrh_password:
+        description: The corresponding password for publishing the Java package to the OSSRH URL provided in gen.yml
+        required: false
+      java_gpg_secret_key:
+        description: The GPG secret key to use for signing the Java package
+        required: false
+      java_gpg_passphrase:
+        description: The passphrase for the GPG secret key
+        required: false
+      slack_webhook_url:
+        description: A Slack webhook URL that pipeline failures will be posted to
+        required: false
+      terraform_gpg_secret_key:
+        description: The GPG secret key to use for signing the Terraform provider
+        required: false
+      terraform_gpg_passphrase:
+        description: The passphrase for the Terraform GPG secret key
+        required: false
+      rubygems_auth_token:
+        description: The auth token (api key) for publishing to RubyGems
+        required: false
+      nuget_api_key:
+        description: The api key for publishing to the Nuget registry
+        required: false
+jobs:
+  validate:
+    name: Validate OpenAPI Document
+    runs-on: ubuntu-latest
+    outputs:
+      resolved_speakeasy_version: ${{ steps.validate.outputs.resolved_speakeasy_version }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - id: validate
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          openapi_doc_location: ${{ inputs.openapi_doc_location }}
+          openapi_doc_auth_header: ${{ inputs.openapi_doc_auth_header }}
+          openapi_doc_auth_token: ${{ secrets.openapi_doc_auth_token }}
+          openapi_docs: ${{ inputs.openapi_docs }}
+          overlay_docs: ${{ inputs.overlay_docs }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: validate
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          working_directory: ${{ inputs.working_directory }}
+          languages: ${{ inputs.languages }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: openapi-doc
+          path: ${{ steps.validate.outputs.openapi_doc }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "OpenAPI Document Validation Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ steps.validate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+  generate:
+    name: Generate SDK
+    runs-on: ubuntu-latest
+    needs: validate
+    outputs:
+      python_regenerated: ${{ steps.generate.outputs.python_regenerated }}
+      python_directory: ${{ steps.generate.outputs.python_directory }}
+      typescript_regenerated: ${{ steps.generate.outputs.typescript_regenerated }}
+      typescript_directory: ${{ steps.generate.outputs.typescript_directory }}
+      go_regenerated: ${{ steps.generate.outputs.go_regenerated }}
+      go_directory: ${{ steps.generate.outputs.go_directory }}
+      terraform_regenerated: ${{ steps.generate.outputs.terraform_regenerated }}
+      terraform_directory: ${{ steps.generate.outputs.terraform_directory }}
+      java_regenerated: ${{ steps.generate.outputs.java_regenerated }}
+      java_directory: ${{ steps.generate.outputs.java_directory }}
+      php_regenerated: ${{ steps.generate.outputs.php_regenerated }}
+      php_directory: ${{ steps.generate.outputs.php_directory }}
+      ruby_regenerated: ${{ steps.generate.outputs.ruby_regenerated }}
+      ruby_directory: ${{ steps.generate.outputs.ruby_directory }}
+      csharp_regenerated: ${{ steps.generate.outputs.csharp_regenerated }}
+      csharp_directory: ${{ steps.generate.outputs.csharp_directory }}
+      swift_regenerated: ${{ steps.generate.outputs.swift_regenerated }}
+      swift_directory: ${{ steps.generate.outputs.swift_directory }}
+      unity_regenerated: ${{ steps.generate.outputs.unity_regenerated }}
+      unity_directory: ${{ steps.generate.outputs.unity_directory }}
+      docs_regenerated: ${{ steps.generate.outputs.docs_regenerated }}
+      docs_directory: ${{ steps.generate.outputs.docs_directory }}
+      branch_name: ${{ steps.generate.outputs.branch_name }}
+      previous_gen_version: ${{ steps.generate.outputs.previous_gen_version }}
+      resolved_speakeasy_version: ${{ steps.generate.outputs.resolved_speakeasy_version }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - id: generate
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          openapi_doc_location: ${{ inputs.openapi_doc_location }}
+          openapi_doc_auth_header: ${{ inputs.openapi_doc_auth_header }}
+          openapi_doc_auth_token: ${{ secrets.openapi_doc_auth_token }}
+          openapi_docs: ${{ inputs.openapi_docs }}
+          overlay_docs: ${{ inputs.overlay_docs }}
+          github_access_token: ${{ secrets.github_access_token }}
+          languages: ${{ inputs.languages }}
+          docs_languages: ${{ inputs.docs_languages }}
+          create_release: ${{ inputs.create_release }}
+          publish_python: ${{ inputs.publish_python }}
+          publish_typescript: ${{ inputs.publish_typescript }}
+          publish_terraform: ${{ inputs.publish_terraform }}
+          publish_java: ${{ inputs.publish_java }}
+          publish_php: ${{ inputs.publish_php }}
+          publish_ruby: ${{ inputs.publish_ruby }}
+          publish_csharp: ${{ inputs.publish_csharp }}
+          mode: ${{ inputs.mode }}
+          action: generate
+          force: ${{ inputs.force }}
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          output_tests: ${{ inputs.output_tests }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          working_directory: ${{ inputs.working_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "SDK Generation Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ steps.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+  compile-go:
+    if: ${{ needs.generate.outputs.go_regenerated == 'true' }}
+    name: Compile Go SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.14.0"
+      - run: go build ./...
+        working-directory: ${{ needs.generate.outputs.go_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Go SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-terraform:
+    if: ${{ needs.generate.outputs.terraform_regenerated == 'true' }}
+    name: Compile Terraform Provider
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.14.0"
+      - run: go build ./...
+        working-directory: ${{ needs.generate.outputs.terraform_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Terraform Provider Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-java:
+    if: ${{ needs.generate.outputs.java_regenerated == 'true' }}
+    name: Compile Java SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "11"
+          cache: "gradle"
+      - run: ./gradlew build --no-daemon -x test && ./gradlew javadoc
+        working-directory: ${{ needs.generate.outputs.java_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Java SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-python:
+    if: ${{ needs.generate.outputs.python_regenerated == 'true' }}
+    name: Compile Python SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - run: pip install -e .[dev]
+        working-directory: ${{ needs.generate.outputs.python_directory }}
+      - run: python3.8 -m compileall -q .
+        working-directory: ${{ needs.generate.outputs.python_directory }}
+      - run: pylint src
+        working-directory: ${{ needs.generate.outputs.python_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Python SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-typescript:
+    if: ${{ needs.generate.outputs.typescript_regenerated == 'true' }}
+    name: Compile Typescript SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: |-
+          [[ "${{ inputs.output_tests }}" == "true" ]] && npm install || npm ci --prefer-offline --no-audit
+          tsc --noEmit --skipLibCheck
+          npx eslint --max-warnings=0 src/**
+        working-directory: ${{ needs.generate.outputs.typescript_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Typescript SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-php:
+    if: ${{ needs.generate.outputs.php_regenerated == 'true' }}
+    name: Compile PHP SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          tools: composer
+      - run: composer install && vendor/bin/phpstan analyse src --level 7 --memory-limit 1G --no-progress
+        working-directory: ${{ needs.generate.outputs.php_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of PHP SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-ruby:
+    if: ${{ needs.generate.outputs.ruby_regenerated == 'true' }}
+    name: Compile Ruby SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: "3.1"
+      - run: gem build && bundle install && rake rubocop
+        working-directory: ${{ needs.generate.outputs.ruby_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Ruby SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-csharp:
+    if: ${{ needs.generate.outputs.csharp_regenerated == 'true' }}
+    name: Compile C# SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - run: dotnet format && dotnet build
+        working-directory: ${{ needs.generate.outputs.csharp_directory }}
+
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of C# SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-swift:
+    if: ${{ needs.generate.outputs.swift_regenerated == 'true' }}
+    name: Compile Swift SDK
+    runs-on: macos-latest
+    timeout-minutes: 30
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+
+      - run: xcodebuild -scheme $(xcodebuild -list -json | jq -r ".workspace.schemes[0]") -destination "$(xcrun simctl list --json | jq -r '[.runtimes[] | select(.platform=="iOS") as $runtime | .supportedDeviceTypes | map(select(.productFamily=="iPhone")) | last | "platform=iOS Simulator,OS=" + $runtime.version + ",name=" + .name][0]')" | xcpretty; exit "${PIPESTATUS[0]}"
+        working-directory: ${{ needs.generate.outputs.swift_directory }}
+
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Swift SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-unity:
+    if: ${{ needs.generate.outputs.unity_regenerated == 'true' }}
+    name: Compile Unity SDK
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "5.x"
+
+      - run: echo "Currently not implemented"
+        working-directory: ${{ needs.generate.outputs.unity_directory }}
+
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Unity SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  compile-docs:
+    if: ${{ needs.generate.outputs.docs_regenerated == 'true' }}
+    name: Compile SDK Docs
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.generate.outputs.branch_name }}
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - run: pnpm i && pnpm run build
+        working-directory: ${{ needs.generate.outputs.docs_directory }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Compilation of Docs Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          RESOLVED_SPEAKEASY_VERSION: ${{ needs.generate.outputs.resolved_speakeasy_version }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "docs"
+  finalize:
+    name: Finalize SDK
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      (needs.compile-go.result != 'skipped' ||
+      needs.compile-terraform.result != 'skipped' ||
+      needs.compile-java.result != 'skipped' ||
+      needs.compile-python.result != 'skipped' ||
+      needs.compile-typescript.result != 'skipped' ||
+      needs.compile-php.result != 'skipped' ||
+      needs.compile-ruby.result != 'skipped' ||
+      needs.compile-csharp.result != 'skipped' ||
+      needs.compile-swift.result != 'skipped' ||
+      needs.compile-docs.result != 'skipped' ||
+      needs.compile-unity.result != 'skipped')
+    needs:
+      - generate
+      - compile-go
+      - compile-terraform
+      - compile-java
+      - compile-python
+      - compile-typescript
+      - compile-php
+      - compile-ruby
+      - compile-csharp
+      - compile-swift
+      - compile-unity
+      - compile-docs
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.finalize.outputs.commit_hash }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - id: Finalize
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        with:
+          github_access_token: ${{ secrets.github_access_token }}
+          languages: ${{ inputs.languages }}
+          create_release: ${{ inputs.create_release }}
+          publish_python: ${{ inputs.publish_python }}
+          publish_typescript: ${{ inputs.publish_typescript }}
+          publish_terraform: ${{ inputs.publish_terraform }}
+          publish_java: ${{ inputs.publish_java }}
+          publish_php: ${{ inputs.publish_php }}
+          publish_ruby: ${{ inputs.publish_ruby }}
+          publish_csharp: ${{ inputs.publish_csharp }}
+          mode: ${{ inputs.mode }}
+          action: finalize
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          branch_name: ${{ needs.generate.outputs.branch_name }}
+          previous_gen_version: ${{ needs.generate.outputs.previous_gen_version }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "SDK Finalization Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+  publish-pypi:
+    if: ${{ always() && needs.generate.outputs.python_regenerated == 'true' && inputs.publish_python == 'true' && inputs.mode != 'pr' }}
+    name: Publish Python SDK
+    runs-on: ubuntu-latest
+    needs: [generate, compile-python, finalize]
+    defaults:
+      run:
+        working-directory: ${{ needs.generate.outputs.python_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.finalize.outputs.commit_hash }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_token }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of Python SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  publish-npm:
+    if: ${{ always() && needs.generate.outputs.typescript_regenerated == 'true' && inputs.publish_typescript == 'true' && inputs.mode != 'pr' }}
+    name: Publish Typescript SDK
+    runs-on: ubuntu-latest
+    needs: [generate, compile-typescript, finalize]
+    defaults:
+      run:
+        working-directory: ${{ needs.generate.outputs.typescript_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.finalize.outputs.commit_hash }}
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: npm install
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        run: npm publish --access public
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of Typescript SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  publish-java:
+    if: ${{ always() && needs.finalize.generate.java_regenerated == 'true' && inputs.publish_java == 'true' && inputs.mode != 'pr' }}
+    name: Publish Java SDK
+    runs-on: ubuntu-latest
+    needs: [generate, compile-java, finalize]
+    defaults:
+      run:
+        working-directory: ${{ needs.generate.outputs.java_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.finalize.outputs.commit_hash }}
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "corretto"
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Publish package
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.ossrh_username }}
+          MAVEN_PASSWORD: ${{ secrets.ossrh_password }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.java_gpg_secret_key }}
+          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_gpg_passphrase }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of Java SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  publish-gems:
+    if: ${{ always() && needs.generate.outputs.ruby_regenerated == 'true' && inputs.publish_ruby == 'true' && inputs.mode != 'pr' }}
+    name: Publish Ruby SDK
+    runs-on: ubuntu-latest
+    needs: [generate, compile-ruby, finalize]
+    defaults:
+      run:
+        working-directory: ${{ needs.generate.outputs.ruby_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.finalize.outputs.commit_hash }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: "3.1"
+      - name: Install dependencies
+        run: gem build && bundle install && rake rubocop
+      - name: Publish
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.rubygems_auth_token }}
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of Ruby SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  publish-nuget:
+    if: ${{ always() && needs.generate.outputs.csharp_regenerated == 'true' && inputs.publish_csharp == 'true' && inputs.mode != 'pr' }}
+    name: Publish C# SDK
+    runs-on: ubuntu-latest
+    needs: [generate, compile-csharp, finalize]
+    defaults:
+      run:
+        working-directory: ${{ needs.generate.outputs.csharp_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.finalize.outputs.commit_hash }}
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+      - name: Publish
+        run: dotnet pack -o . && dotnet nuget push *.nupkg --api-key ${{ secrets.nuget_api_key }} --source https://api.nuget.org/v3/index.json
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of C# SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"
+  publish-packagist:
+    if: ${{ always() && needs.generate.outputs.php_regenerated == 'true' && inputs.publish_php == 'true' && inputs.mode != 'pr' }}
+    name: Publish PHP SDK
+    runs-on: ubuntu-latest
+    needs: [generate, compile-php, finalize]
+    defaults:
+      run:
+        working-directory: ${{ needs.generate.outputs.php_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - name: Publish
+        uses: speakeasy-api/packagist-update@support-github-creation
+        with:
+          username: ${{ secrets.packagist_username }}
+          api_token: ${{ secrets.packagist_token }}
+          package_name: ${{ github.repository }}
+          package_base_url: ${{ github.server_url }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of PHP SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - id: log-result
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        if: always()
+        with:
+          speakeasy_version: ${{ inputs.speakeasy_version }}
+          github_access_token: ${{ secrets.github_access_token }}
+          action: log-result
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          languages: ${{ inputs.languages }}
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v14.28"
+          GH_ACTION_STEP: ${{ github.job }}
+          TARGET_TYPE: "sdk"

--- a/.github/workflows/speakeasy/sdk-publish.yaml
+++ b/.github/workflows/speakeasy/sdk-publish.yaml
@@ -1,0 +1,393 @@
+name: Speakeasy SDK Publish Workflow
+
+on:
+  workflow_call:
+    inputs:
+      create_release:
+        description: "Create a Github release"
+        default: "true"
+        required: false
+        type: string
+      publish_python:
+        description: "Publish the Python SDK to PyPi if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_typescript:
+        description: "Publish the Typescript SDK to NPM if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_java:
+        description: "Publish the Java SDK to the OSSRH URL configured in gen.yml if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_php:
+        description: "Publish the PHP SDK for Composer if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_ruby:
+        description: "Publish the Ruby SDK for RubyGems if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_csharp:
+        description: "Publish the C# SDK for nuget if using 'direct' mode or prepare a release if using 'pr' mode"
+        default: "false"
+        required: false
+        type: string
+      publish_terraform:
+        description: "Create a Github release compatible with the terraform registry of the provider"
+        default: "false"
+        required: false
+        type: string
+      speakeasy_server_url:
+        required: false
+        description: "Internal use only"
+        type: string
+      dotnet_version:
+        description: "The version of dotnet to use when compiling the C# SDK"
+        required: false
+        type: string
+        default: "5.x"
+    secrets:
+      github_access_token:
+        description: A GitHub access token with write access to the repo
+        required: true
+      pypi_token:
+        description: A PyPi access token for publishing the package to PyPi, include the `pypi-` prefix
+        required: false
+      npm_token:
+        description: An NPM access token for publishing the package to NPM, include the `npm_` prefix
+        required: false
+      packagist_username:
+        description: A Packagist username for publishing the package to Packagist
+        required: false
+      packagist_token:
+        description: A Packagist API token for publishing the package to Packagist
+        required: false
+      speakeasy_api_key:
+        description: The API key to use to authenticate the Speakeasy CLI
+        required: true
+      ossrh_username:
+        description: A username for publishing the Java package to the OSSRH URL provided in gen.yml
+        required: false
+      ossrh_password:
+        description: The corresponding password for publishing the Java package to the OSSRH URL provided in gen.yml
+        required: false
+      java_gpg_secret_key:
+        description: The GPG secret key to use for signing the Java package
+        required: false
+      java_gpg_passphrase:
+        description: The passphrase for the GPG secret key
+        required: false
+      slack_webhook_url:
+        description: A Slack webhook URL that pipeline failures will be posted to
+        required: false
+      rubygems_auth_token:
+        description: The auth token (api key) for publishing to RubyGems
+        required: false
+      nuget_api_key:
+        description: The api key for publishing to Nuget
+        required: false
+jobs:
+  release:
+    name: Create Github Release
+    runs-on: ubuntu-latest
+    outputs:
+      python_regenerated: ${{ steps.release.outputs.python_regenerated }}
+      python_directory: ${{ steps.release.outputs.python_directory }}
+      typescript_regenerated: ${{ steps.release.outputs.typescript_regenerated }}
+      typescript_directory: ${{ steps.release.outputs.typescript_directory }}
+      terraform_regenerated: ${{ steps.release.outputs.terraform_regenerated }}
+      terraform_directory: ${{ steps.release.outputs.terraform_directory }}
+      go_regenerated: ${{ steps.release.outputs.go_regenerated }}
+      go_directory: ${{ steps.release.outputs.go_directory }}
+      java_regenerated: ${{ steps.release.outputs.java_regenerated }}
+      java_directory: ${{ steps.release.outputs.java_directory }}
+      php_regenerated: ${{ steps.release.outputs.php_regenerated }}
+      php_directory: ${{ steps.release.outputs.php_directory }}
+      ruby_regenerated: ${{ steps.release.outputs.ruby_regenerated }}
+      ruby_directory: ${{ steps.release.outputs.ruby_directory }}
+      csharp_regenerated: ${{ steps.release.outputs.csharp_regenerated }}
+      csharp_directory: ${{ steps.release.outputs.csharp_directory }}
+      swift_regenerated: ${{ steps.release.outputs.swift_regenerated }}
+      swift_directory: ${{ steps.release.outputs.swift_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - id: release
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        with:
+          github_access_token: ${{ secrets.github_access_token }}
+          create_release: ${{ inputs.create_release }}
+          publish_python: ${{ inputs.publish_python }}
+          publish_typescript: ${{ inputs.publish_typescript }}
+          publish_terraform: ${{ inputs.publish_terraform }}
+          publish_java: ${{ inputs.publish_java }}
+          publish_php: ${{ inputs.publish_php }}
+          publish_ruby: ${{ inputs.publish_ruby }}
+          publish_csharp: ${{ inputs.publish_csharp }}
+          action: "release"
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Failed to create Github Release"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-pypi:
+    if: ${{ needs.release.outputs.python_regenerated == 'true' && inputs.publish_python == 'true' }}
+    name: Publish Python SDK
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: ${{ needs.release.outputs.python_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_token }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Failed to publish Python SDK"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-npm:
+    if: ${{ needs.release.outputs.typescript_regenerated == 'true' && inputs.publish_typescript == 'true' }}
+    name: Publish Typescript SDK
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: ${{ needs.release.outputs.typescript_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: npm install
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        run: npm publish --access public
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Failed to publish Typescript SDK"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-java:
+    if: ${{ needs.release.outputs.java_regenerated == 'true' && inputs.publish_java == 'true' }}
+    name: Publish Java SDK
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: ${{ needs.release.outputs.java_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "corretto"
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Publish package
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.ossrh_username }}
+          MAVEN_PASSWORD: ${{ secrets.ossrh_password }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.java_gpg_secret_key }}
+          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_gpg_passphrase }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Failed to publish Java SDK"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-packagist:
+    if: ${{ needs.release.outputs.php_regenerated == 'true' && inputs.publish_php == 'true' }}
+    name: Publish PHP SDK
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: ${{ needs.release.outputs.php_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - name: Publish
+        uses: speakeasy-api/packagist-update@support-github-creation
+        with:
+          username: ${{ secrets.packagist_username }}
+          api_token: ${{ secrets.packagist_token }}
+          package_name: ${{ github.repository }}
+          package_base_url: ${{ github.server_url }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Failed to publish PHP SDK"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-nuget:
+    if: ${{ needs.release.outputs.csharp_regenerated == 'true' && inputs.publish_csharp == 'true' }}
+    name: Publish C# SDK
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: ${{ needs.release.outputs.csharp_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+      - name: Publish
+        run: dotnet pack -o . && dotnet nuget push *.nupkg --api-key ${{ secrets.nuget_api_key }} --source https://api.nuget.org/v3/index.json
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of C# SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-terraform:
+    if: ${{ needs.release.outputs.terraform_regenerated == 'true' && inputs.publish_terraform == 'true' }}
+    name: Publish Terraform Provider
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          install-only: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.TERRAFORM_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TERRAFORM_GPG_PASSPHRASE }}
+      - id: release
+        uses: speakeasy-api/sdk-generation-action@v14.28
+        with:
+          github_access_token: ${{ secrets.github_access_token }}
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
+          action: "release"
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_access_token }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of Terraform Provider Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  publish-gems:
+    if: ${{ needs.release.outputs.ruby_regenerated == 'true' && inputs.publish_ruby == 'true' }}
+    name: Publish Ruby SDK
+    runs-on: ubuntu-latest
+    needs: release
+    defaults:
+      run:
+        working-directory: ${{ needs.release.outputs.ruby_directory }}
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: "3.1"
+      - name: Install dependencies
+        run: gem build && bundle install && rake rubocop
+      - name: Publish
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.rubygems_auth_token }}
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Publishing of Ruby SDK Failed"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -15,7 +15,7 @@ permissions:
     - cron: 0 0 * * *
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
+    uses: hathora/cloud-sdk-typescript/.github/workflows/speakeasy/sdk-generation.yaml
     with:
       force: ${{ github.event.inputs.force }}
       languages: |

--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -7,7 +7,7 @@ name: Publish
       - RELEASES.md
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14
+    uses: hathora/cloud-sdk-typescript/.github/workflows/speakeasy/sdk-publish.yaml
     with:
       create_release: true
       publish_typescript: true


### PR DESCRIPTION
This PR will pin this repo to use version `v14.28` of the https://github.com/speakeasy-api/sdk-generation-action as a pinned version of the speakeasy CLI is being used and newer versions of the action will incompatible with this older version of the CLI.

This is done by creating copies of the imported workflow files from the `sdk-generation-action` repo and updated the version numbers to `v14.28`