### PR TITLE
Add 'v' prefix to speakeasy cli version

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -24,7 +24,7 @@ jobs:
       openapi_docs: |
         - https://hathora.dev/swagger.json
       publish_typescript: true
-      speakeasy_version: 1.120.0
+      speakeasy_version: v1.120.0
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
The git tags used on the speakeasy CLI repository all start with a 'v' character, i.e. v1.120.0, which might explain why the action is currently fail to find a release binary.