### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@hathora/cloud-sdk-typescript",
   "version": "2.27.0",
   "author": "Hathora",
+  "license": "MIT",
   "main": "./index.js",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
## Summary

Adds missing MIT license metadata to the `@hathora/cloud-sdk-typescript` package manifest.

The repository already includes an MIT `LICENSE.md`, but the package manifest does not currently publish a `license` field.

## Verification

- Confirmed current npm metadata for `@hathora/cloud-sdk-typescript` has no license field.
- Confirmed `LICENSE.md` contains the MIT license text.
- Verified the updated package manifest now declares `license: "MIT"`.
- Ran `git diff --check`.
- Ran `npm pack --dry-run --ignore-scripts --json`.
